### PR TITLE
feat: bump code sniffer standard to 29.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-        - "7.4"
-        - "8.0"
         - "8.1"
         - "8.2"
         - "8.3"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "bin/phpcs-baseliner"
     ],
     "require-dev": {
-        "iodigital-com/php-code-sniffer-standard": "^29.0",
+        "iodigital-com/php-code-sniffer-standard": "^29.2",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.6.8",
         "phpstan/phpstan-phpunit": "^1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-simplexml": "*",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,8 +4,8 @@
   <file>tests</file>
   <exclude-pattern>/tests/Fixtures/</exclude-pattern>
   <rule ref="IO"/>
-  <config name="php_version" value="70300"/>
-  <config name="testVersion" value="7.3-8.2"/>
+  <config name="php_version" value="80100"/>
+  <config name="testVersion" value="8.1-8.3"/>
   <arg name="extensions" value="php"/>
   <arg name="cache"/>
 </ruleset>

--- a/src/Application.php
+++ b/src/Application.php
@@ -18,7 +18,6 @@ use Throwable;
 
 use function array_shift;
 use function count;
-use function get_class;
 use function sprintf;
 
 use const PHP_EOL;
@@ -42,7 +41,7 @@ class Application
     /**
      * @var BaselineCreator
      */
-    private $baselineCreator;
+    private BaselineCreator $baselineCreator;
 
     public function __construct(
         BaselineCreator $baselineCreator
@@ -97,7 +96,7 @@ class Application
             $this->showHelp($command);
         } else {
             throw new InvalidArgumentException(
-                sprintf('Unable to handle command of type \'%s\'.', get_class($command))
+                sprintf('Unable to handle command of type \'%s\'.', $command::class)
             );
         }
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -104,12 +104,6 @@ class Application
 
     private function showHelp(ShowHelp $command): void
     {
-        echo <<<HELP
-Usage: {$command->getCommandName()} [command]
-
-Available commands:
-  create-baseline      Create a new baseline
-
-HELP;
+        echo sprintf('Usage: %s [command] create-baseline', $command->getCommandName());
     }
 }

--- a/src/Baseline/Baseline.php
+++ b/src/Baseline/Baseline.php
@@ -9,7 +9,7 @@ class Baseline
     /**
      * @var array<array<array<string>>>
      */
-    private $violatedRulesByFileAndLineNumber;
+    private array $violatedRulesByFileAndLineNumber;
 
     /**
      * @param array<array<array<string>>> $violatedRulesByFileAndLineNumber

--- a/src/BaselineCreator.php
+++ b/src/BaselineCreator.php
@@ -17,27 +17,27 @@ class BaselineCreator
     /**
      * @var BasePathFinder
      */
-    private $basePathFinder;
+    private BasePathFinder $basePathFinder;
     /**
      * @var Runner
      */
-    private $runner;
+    private Runner $runner;
     /**
      * @var BaselineFactory
      */
-    private $baselineFactory;
+    private BaselineFactory $baselineFactory;
     /**
      * @var Filesystem
      */
-    private $filesystem;
+    private Filesystem $filesystem;
     /**
      * @var AddBaselineProcessor
      */
-    private $addBaselineProcessor;
+    private AddBaselineProcessor $addBaselineProcessor;
     /**
      * @var OutputWriter
      */
-    private $outputWriter;
+    private OutputWriter $outputWriter;
 
     public function __construct(
         BasePathFinder $basePathFinder,

--- a/src/Command/ShowHelp.php
+++ b/src/Command/ShowHelp.php
@@ -9,7 +9,7 @@ class ShowHelp
     /**
      * @var string
      */
-    private $commandName;
+    private string $commandName;
 
     public function __construct(string $commandName)
     {

--- a/src/PhpCodeSnifferRunner/Report/FileReport.php
+++ b/src/PhpCodeSnifferRunner/Report/FileReport.php
@@ -9,15 +9,15 @@ class FileReport
     /**
      * @var int
      */
-    private $errorCount;
+    private int $errorCount;
     /**
      * @var int
      */
-    private $warningCount;
+    private int $warningCount;
     /**
      * @var array<Message>
      */
-    private $messages;
+    private array $messages;
 
     /**
      * @param array<Message> $messages

--- a/src/PhpCodeSnifferRunner/Report/Message.php
+++ b/src/PhpCodeSnifferRunner/Report/Message.php
@@ -9,31 +9,31 @@ class Message
     /**
      * @var string
      */
-    private $message;
+    private string $message;
     /**
      * @var string
      */
-    private $source;
+    private string $source;
     /**
      * @var int
      */
-    private $severity;
+    private int $severity;
     /**
      * @var bool
      */
-    private $fixable;
+    private bool $fixable;
     /**
      * @var string
      */
-    private $type;
+    private string $type;
     /**
      * @var int
      */
-    private $line;
+    private int $line;
     /**
      * @var int
      */
-    private $column;
+    private int $column;
 
     public function __construct(
         string $message,

--- a/src/PhpCodeSnifferRunner/Report/Report.php
+++ b/src/PhpCodeSnifferRunner/Report/Report.php
@@ -9,11 +9,11 @@ class Report
     /**
      * @var Totals
      */
-    private $totals;
+    private Totals $totals;
     /**
      * @var array<FileReport>
      */
-    private $fileReportsByFilename;
+    private array $fileReportsByFilename;
 
     /**
      * @param array<FileReport> $fileReportsByFilename

--- a/src/PhpCodeSnifferRunner/Report/Totals.php
+++ b/src/PhpCodeSnifferRunner/Report/Totals.php
@@ -6,18 +6,9 @@ namespace IODigital\CodeSnifferBaseliner\PhpCodeSnifferRunner\Report;
 
 class Totals
 {
-    /**
-     * @var int
-     */
-    private $errors;
-    /**
-     * @var int
-     */
-    private $warnings;
-    /**
-     * @var int
-     */
-    private $fixable;
+    private int $errors;
+    private int $warnings;
+    private int $fixable;
 
     public function __construct(int $errors, int $warnings, int $fixable)
     {

--- a/src/PhpTokenizer/Token.php
+++ b/src/PhpTokenizer/Token.php
@@ -24,15 +24,15 @@ class Token
     /**
      * @var int
      */
-    private $type;
+    private int $type;
     /**
      * @var string
      */
-    private $contents;
+    private string $contents;
     /**
      * @var int
      */
-    private $startingLineNumber;
+    private int $startingLineNumber;
 
     public function __construct(int $type, string $contents, int $startingLineNumber)
     {

--- a/src/PhpTokenizer/TokenizedSourceCode.php
+++ b/src/PhpTokenizer/TokenizedSourceCode.php
@@ -26,11 +26,11 @@ class TokenizedSourceCode implements IteratorAggregate
     /**
      * @var array<array<Token>>
      */
-    private $tokensByStartingLineNumber = [];
+    private array $tokensByStartingLineNumber = [];
     /**
      * @var array<int, array<Token>>
      */
-    private $tokensByEndingLineNumber = [];
+    private array $tokensByEndingLineNumber = [];
 
     /**
      * @param array<Token> $tokens

--- a/src/SourceCodeProcessor/AddBaselineProcessor.php
+++ b/src/SourceCodeProcessor/AddBaselineProcessor.php
@@ -41,6 +41,10 @@ class AddBaselineProcessor
     public function addRuleExclusionsByLineNumber(string $sourceCode, array $ruleExclusionsByLineNumber): string
     {
         $lines = preg_split(sprintf("/\r?\n/"), $sourceCode);
+        if ($lines === false) {
+            return $sourceCode;
+        }
+
         $tokenizedSourceCode = (new Tokenizer())->tokenize($sourceCode);
 
         $lineNumbersAdded = [];

--- a/src/SourceCodeProcessor/AddBaselineProcessor.php
+++ b/src/SourceCodeProcessor/AddBaselineProcessor.php
@@ -27,7 +27,7 @@ class AddBaselineProcessor
     /**
      * @var InstructionCommentLineParser
      */
-    private $ignoreCommentParser;
+    private InstructionCommentLineParser $ignoreCommentParser;
 
     public function __construct(
         InstructionCommentLineParser $ignoreCommentLineParser

--- a/src/SourceCodeProcessor/InstructionComment.php
+++ b/src/SourceCodeProcessor/InstructionComment.php
@@ -18,23 +18,23 @@ class InstructionComment
     /**
      * @var string
      */
-    private $indentation;
+    private string $indentation;
     /**
      * @var string
      */
-    private $commentStart;
+    private string $commentStart;
     /**
      * @var string
      */
-    private $instruction;
+    private string $instruction;
     /**
      * @var array<string>
      */
-    private $rules;
+    private array $rules;
     /**
      * @var array<string>
      */
-    private $messages;
+    private array $messages;
 
     /**
      * @param array<string> $rules

--- a/src/SourceCodeProcessor/InstructionCommentLineParser.php
+++ b/src/SourceCodeProcessor/InstructionCommentLineParser.php
@@ -17,17 +17,14 @@ class InstructionCommentLineParser
 
     public function parse(string $line): ?InstructionComment
     {
-        if (
-            preg_match(self::PHPCS_IGNORE_COMMENT_REGULAR_EXPRESSION, $line, $matches) !== 1
-            || !array_key_exists('instruction', $matches)
-        ) {
+        if (preg_match(self::PHPCS_IGNORE_COMMENT_REGULAR_EXPRESSION, $line, $matches) !== 1) {
             return null;
         }
 
         $rules = array_key_exists('rules', $matches) ? $this->parseRules($matches['rules']) : [];
         $messages = array_key_exists('message', $matches) ? $this->parseMessages($matches['message']) : [];
-        $indentation = array_key_exists('indentation', $matches) ? $matches['indentation'] : '';
-        $commentStart = array_key_exists('comment_start', $matches) ? $matches['comment_start'] : '';
+        $indentation = $matches['indentation'];
+        $commentStart = $matches['comment_start'];
 
         return new InstructionComment($matches['instruction'], $rules, $messages, $indentation, $commentStart);
     }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -47,7 +47,7 @@ PHP;
     /**
      * @var Application
      */
-    private $application;
+    private Application $application;
 
     protected function setUp(): void
     {

--- a/tests/Baseline/BaselineFactoryTest.php
+++ b/tests/Baseline/BaselineFactoryTest.php
@@ -15,7 +15,7 @@ class BaselineFactoryTest extends TestCase
     /**
      * @var BaselineFactory
      */
-    private $baselineFactory;
+    private BaselineFactory $baselineFactory;
 
     protected function setUp(): void
     {

--- a/tests/BaselineCreatorTest.php
+++ b/tests/BaselineCreatorTest.php
@@ -36,15 +36,15 @@ PHP;
     /**
      * @var BaselineCreator
      */
-    private $baselineCreator;
+    private BaselineCreator $baselineCreator;
     /**
      * @var MemoryFilesystem
      */
-    private $filesystem;
+    private MemoryFilesystem $filesystem;
     /**
      * @var Runner&MockObject
      */
-    private $runnerMock;
+    private Runner&MockObject $runnerMock;
 
     protected function setUp(): void
     {

--- a/tests/Filesystem/MemoryFilesystem.php
+++ b/tests/Filesystem/MemoryFilesystem.php
@@ -11,7 +11,7 @@ class MemoryFilesystem implements Filesystem
     /**
      * @var array<string>
      */
-    private $fileContentsByFilename = [];
+    private array $fileContentsByFilename = [];
 
     public function readContents(string $filename): string
     {

--- a/tests/SourceCodeProcessor/AddBaselineProcessorTest.php
+++ b/tests/SourceCodeProcessor/AddBaselineProcessorTest.php
@@ -12,7 +12,7 @@ class AddBaselineProcessorTest extends TestCase
     /**
      * @var AddBaselineProcessor
      */
-    private $addBaselineProcessor;
+    private AddBaselineProcessor $addBaselineProcessor;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Resolves some PHPCS and PHPStan warnings, bump code sniffer to 29.2, drop support for PHP 7.4 and 8.0